### PR TITLE
fix: Resolves video quality in segments - #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Parameters
 
 Implementation Details
 
-- The function utilizes the `fluent-ffmpeg` library to process the video and cut the segments according to the provided timestamps.
+- The function utilizes `ffmpeg` to cut the segments according to the provided timestamps.
 - Unique file names are generated for each video segment based on the current date and time.
 - Events are handled to capture the successful completion of the cutting process or any errors that may occur during the process.
 
@@ -116,7 +116,7 @@ Parameters
 
 Implementation Details
 
-- The function utilizes the **ffmpeg** library to perform video concatenation.
+- The function utilizes **ffmpeg** to perform video concatenation.
 - Video files in the input directory are validated, and those containing the `segment{segment_number}` tag in their name are filtered.
 - A concatenation list file (`concat.txt`) is generated, specifying the order of the videos to concatenate.
 - The **ffmpeg** command is executed to concatenate the videos.

--- a/captureAndCutVideo/captureAndCutVideo.js
+++ b/captureAndCutVideo/captureAndCutVideo.js
@@ -1,59 +1,65 @@
-import fs from "fs";
-import ffmpeg from "fluent-ffmpeg";
 import path from "path";
+import cp from "child_process";
 
 import subtractTimestamps from "./subtractTimestamps.js";
 
-const captureAndCutVideo = (
+const captureAndCutVideo = async (
   inputVideoDirectory,
   timestamps,
   temporalVideoName,
   videoFormat,
   outputDirectory
 ) => {
-  return new Promise(async (resolve) => {
-    if (!fs.existsSync(outputDirectory)) {
-      console.error("Output folder does not exist");
-      return;
-    }
-    // Add the temporary name of the video to the path
-    const videoPath = path.join(inputVideoDirectory, temporalVideoName);
-    // Add temporary video format
-    const videoPathWithFormat = `${videoPath}${videoFormat}`;
+  const videoPath = path.join(inputVideoDirectory, temporalVideoName);
+  const videoPathWithFormat = `${videoPath}${videoFormat}`;
+  const promises = [];
 
-    const promises = [];
+  timestamps.forEach((timestamp, index) => {
+    const { start, end } = timestamp;
+    const outputFileName =
+      new Date().toISOString().replace(/:/g, "-") +
+      `_segment_${index + 1}${videoFormat}`;
+    const outputFilePath = path.join(outputDirectory, outputFileName);
 
-    timestamps.forEach((timestamp, index) => {
-      const { start, end } = timestamp;
-      const outputFileName =
-        new Date().toISOString().replace(/:/g, "-") +
-        `_segment_${index + 1}${videoFormat}`;
-      const outputFilePath = path.join(outputDirectory, outputFileName);
-      const promise = new Promise((resolve, reject) => {
-        ffmpeg(videoPathWithFormat)
-          .setStartTime(start)
-          .setDuration(subtractTimestamps(end, start))
-          .on("end", () => {
-            console.log(`Segment ${index + 1} saved: ${outputFileName}`);
-            resolve();
-          })
-          .on("error", (err) => {
-            console.error(
-              `Error processing segment ${index + 1}: ${err.message}`
-            );
-            reject(`Error processing segment ${index + 1}: ${err.message}`);
-          })
-          .save(outputFilePath);
+    const durationClip = subtractTimestamps(end, start);
+
+    const ffmpegProcess = cp.spawn("ffmpeg", [
+      "-ss",
+      start,
+      "-i",
+      videoPathWithFormat,
+      "-t",
+      durationClip,
+      "-map",
+      "0",
+      "-c",
+      "copy",
+      outputFilePath,
+    ]);
+
+    const promise = new Promise((resolve, reject) => {
+      ffmpegProcess.on("close", (code) => {
+        if (code === 0) {
+          console.log(`Segment ${index + 1} saved: ${outputFileName}`);
+          resolve();
+        } else {
+          const errorMessage = `Error processing segment ${
+            index + 1
+          }. Exit code: ${code}`;
+          console.error(errorMessage);
+          reject(errorMessage);
+        }
       });
+    });
 
-      promises.push(promise);
-    });
-    await Promise.all(promises);
-    resolve({
-      promises,
-      temporalVideoPath: videoPathWithFormat,
-    });
+    promises.push(promise);
   });
+
+  await Promise.all(promises);
+
+  return {
+    temporalVideoPath: videoPathWithFormat,
+  };
 };
 
 export default captureAndCutVideo;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,47 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "child_process": "^1.0.2",
-        "fluent-ffmpeg": "^2.1.2"
+        "child_process": "^1.0.2"
       }
-    },
-    "node_modules/async": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
     "node_modules/child_process": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
       "integrity": "sha512-Wmza/JzL0SiWz7kl6MhIKT5ceIlnFPJX+lwUGj7Clhy5MMldsSoJR0+uvRzOS5Kv45Mq7t1PoE8TsOA9bzvb6g=="
-    },
-    "node_modules/fluent-ffmpeg": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.2.tgz",
-      "integrity": "sha512-IZTB4kq5GK0DPp7sGQ0q/BWurGHffRtQQwVkiqDgeO6wYJLLV5ZhgNOQ65loZxxuPMKZKZcICCUnaGtlxBiR0Q==",
-      "dependencies": {
-        "async": ">=0.2.9",
-        "which": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    },
-    "node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "child_process": "^1.0.2",
-    "fluent-ffmpeg": "^2.1.2"
+    "child_process": "^1.0.2"
   }
 }

--- a/utils/functions.js
+++ b/utils/functions.js
@@ -122,6 +122,5 @@ export const getExtension = async (directoryPath, videoName) => {
     }
   } catch (error) {
     console.error(error);
-    return ".mp4";
   }
 };


### PR DESCRIPTION
## Correction of low video quality in the segments prior to concatenation

### This pull request adds the following fixes:
- Avoid video re-processing by adding the `-c copy` option to the ffmpeg command.
- Uninstall fluent-ffmpeg as it will not be necessary.
- Update README.md file