### PR TITLE
Fix/timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,28 @@ Implementation Details
 - Video files in the input directory are validated, and those containing the `segment{segment_number}` tag in their name are filtered.
 - A concatenation list file (`concat.txt`) is generated, specifying the order of the videos to concatenate.
 - The **ffmpeg** command is executed to concatenate the videos.
+
+## Main validations
+
+### validations function
+
+Description
+
+The validations.js function is responsible for centrally managing the main validations in the script, the existence of a directory, the correction of timestamps and the maximum duration of the video.
+
+Parameters
+
+`videoUrl`: (string) URL of the video to validate.
+`timestamps`: (array) Array of objects that represent the timestamps of the video.
+`directoryPath`: (string) Path of the directory where the video is located.
+
+Implementation Details
+
+- Validates the existence of the directory specified by `directoryPath` using the `validateDirectoryExists` function.
+- Check that all timestamps in `timestamps` array have the start property less than the end property using the `validateTimestamps` function.
+- Check that the maximum timestamp duration in `timestamps` array does not exceed the video duration in `videoUrl` using the `validateMaxDuration` function.
+
+Exceptions
+
+- If any of the validations fail, the function will throw an exception that will be caught in a `catch` block.
+- The exception will include a message describing the error and the execution stack if an error has occurred.

--- a/captureAndCutVideo/captureAndCutVideo.js
+++ b/captureAndCutVideo/captureAndCutVideo.js
@@ -24,17 +24,23 @@ const captureAndCutVideo = async (
     const durationClip = subtractTimestamps(end, start);
 
     const ffmpegProcess = cp.spawn("ffmpeg", [
-      "-ss",
-      start,
       "-i",
       videoPathWithFormat,
+      "-ss",
+      start, // Start time
       "-t",
-      durationClip,
-      "-map",
-      "0",
-      "-c",
-      "copy",
-      outputFilePath,
+      durationClip, // clip duration
+      // Lightweight recoding
+      "-c:v",
+      "libx264", // Encoder H.264
+      "-preset",
+      "veryfast", // Preset to speed up encoding
+      "-crf",
+      "23", // Quality: 0 is lossless, 23 is good quality, 51 is the lowest
+
+      "-c:a",
+      "aac", // AAC audio encoder
+      outputFilePath.replace(".webm", ".mp4"), // Output file
     ]);
 
     const promise = new Promise((resolve, reject) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "child_process": "^1.0.2",
         "cli-progress": "^3.12.0"
       }
     },
@@ -20,11 +19,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha512-Wmza/JzL0SiWz7kl6MhIKT5ceIlnFPJX+lwUGj7Clhy5MMldsSoJR0+uvRzOS5Kv45Mq7t1PoE8TsOA9bzvb6g=="
     },
     "node_modules/cli-progress": {
       "version": "3.12.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "child_process": "^1.0.2",
     "cli-progress": "^3.12.0"
   }
 }


### PR DESCRIPTION
# Pull Request: Fix for Accurate Clip Extraction Timing
## Description
This pull request addresses an issue with the script responsible for extracting clips from a video. Previously, the extracted clips did not match the timestamps provided as references for segment extraction. The added command ensures that the extracted clip timings are more accurate by incorporating lightweight recoding.
## Changes Made
The following command was added to the script to resolve the issue:
```
const ffmpegProcess = cp.spawn("ffmpeg", [
  "-i",
  videoPathWithFormat,
  "-ss",
  start, // Start time
  "-t",
  durationClip, // Clip duration
  // Lightweight recoding
  "-c:v",
  "libx264", // Encoder H.264
  "-preset",
  "veryfast", // Preset to speed up encoding
  "-crf",
  "23", // Quality: 0 is lossless, 23 is good quality, 51 is the lowest

  "-c:a",
  "aac", // AAC audio encoder
  outputFilePath.replace(".webm", ".mp4"), // Output file
]);
```
## Testing

- Verified that the extracted clips now match the provided timestamps accurately.
- Tested with multiple video files to ensure consistent results.

## Additional Notes
The lightweight recoding with H.264 and AAC ensures that the encoding process is efficient while maintaining good quality.