### PR TITLE
Support different video formats and extensions and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 concat.txt
+yt-dlp

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ npm install
 
 The script will process the videos according to the specified timestamps, generating a new video for each timestamp in addition to concatenating the corresponding sections.
 
+
+## Script tested with
+| Test description |  Test result  |
+|:-----|:--------:|
+| A 1440p/60fps gameplay video downloaded from Youtube with .mp4 extension   | `TEST PASSED` |
+| A 1440p/60fps gameplay video downloaded from Youtube with .webm extension   |  `TEST PASSED`  |
+| One 1440p/60fps gameplay video downloaded from Youtube with .webm extension and one 1440p/60fps gameplay video downloaded from Youtube with .mp4 extension |  `TEST PASSED`  |
+| One 1440p/60fps gameplay video recorded with OBS with .mkv extension which contains multiple audio streams. Audio streams were saved in resulting video |  `TEST PASSED`  |
+| One 1440p/60fps gameplay video recorded with OBS with .mkv extension which contains multiple audio streams in combination with one 1440p/60fps gameplay video downloaded from Youtube with .webm extension that only contained one audio stream. The result included decent video quality, plus first audio stream from both .mkv and .webm videos. All other audio streams were droppped. |  `TEST DECENTLY PASSED` (only first audio stream for each source video was included)  |
+
+
 ## Object config values
 
 The `config` file contains the following configuration options:

--- a/config.js
+++ b/config.js
@@ -1,20 +1,25 @@
 export const config = {
-  ffmpeg_exe_path: "ffmpeg",
-  ffprobe_exe_path: "ffprobe",
-  workingFolderPath: "C:/users/aaron/downloads/result/",
-  segmentsFolderPath: "C:/users/aaron/downloads/result/segments/",
-  deleteDownloadedVideos: true,
+  ffmpeg_exe_path: "C:/ProgramData/chocolatey/lib/ffmpeg/tools/ffmpeg/bin/ffmpeg.exe",
+  ffprobe_exe_path: "C:/ProgramData/chocolatey/lib/ffmpeg/tools/ffmpeg/bin/ffprobe.exe",
+  workingFolderPath: "C:/projects/youtube_video_slicer/output/",
+  segmentsFolderPath: "C:/projects/youtube_video_slicer/output/segments/",
+  deleteDownloadedVideos: false,
   timestamps: [
     {
-      start: "00:00:05.478",
-      end: "00:00:15.951",
-      url: "",
+      start: "00:01:10.000",
+      end: "00:01:20.000", //
+      path: "E:/obs/testing/Halo_4___gKUJotXalGU.webm"
+    },
+    {
+      start: "00:05:30.000",
+      end: "00:05:55.000", //
+      path: "E:/obs/ghost_recon_wildlands_2025-06-05 21-44-37.mkv"
     },
   ],
-  concurrencyLimit: 2,
+  concurrencyLimit: 4,
   shortsConfig: {
-    shortThumbnailPath: "C:/users/aaron/downloads/result/short_1.png",
-    generateThumbnail: true,
+    shortThumbnailPath: "",
+    generateThumbnail: false,
   },
-  isYoutubeShort: true,
+  isYoutubeShort: false,
 };

--- a/cutAndConcatenateVideo/concatenateSegments.js
+++ b/cutAndConcatenateVideo/concatenateSegments.js
@@ -13,7 +13,8 @@ async function concatenateSegments(file, videoName) {
 
     const fileNameOutputWithoutExtension = `_final_result_${videoName}`;
     const fullPathOutputVideo = `${workingFolderPath}${fileNameOutputWithoutExtension}${getTargetExtension()}`;
-    const concatCommand = `${ffmpeg_exe_path} -f concat -safe 0 -i ${fileConcatFullPath} -c copy ${fullPathOutputVideo}`;
+
+    const concatCommand = `${ffmpeg_exe_path} -f concat -safe 0 -i ${fileConcatFullPath} -map 0 -c copy ${fullPathOutputVideo}`;
     await execP(concatCommand);
 
     if (isYoutubeShort === true) {

--- a/cutAndConcatenateVideo/processTimestamp.js
+++ b/cutAndConcatenateVideo/processTimestamp.js
@@ -5,33 +5,57 @@ import { config } from "../config.js";
 
 const { ffprobe_exe_path } = config;
 
-const processTimestamp = async (timestamp, sortableDate) => {
+const processTimestamp = async (timestamp, sortableDate, shouldAvoidOptimizations) => {
   const extension = path.extname(timestamp.path);
   try {
-    const command = `${ffprobe_exe_path} -loglevel error -select_streams v:0 -show_entries packet=pts_time,flags -of csv=print_section=0 ${timestamp.path}`;
-    const result = await execP(command, { maxBuffer: 1048576000 });
+    /**
+     * If shouldAvoidOptimizations is true, we don't even bother to get the keyframes from
+     * the video, since we won't even use them later in the script.
+     */
+    if (shouldAvoidOptimizations) {
+      const timestampsInSeconds = {
+        start: getSeconds(timestamp.start),
+        end: getSeconds(timestamp.end),
+      };
 
-    const keyframes = [];
-    result.stdout.split(/\r?\n/).forEach((keyframe) => {
-      if (keyframe.includes("K_")) {
-        keyframes.push(parseFloat(keyframe.replace(",K__", "")));
-      }
-    });
+      const { file, commands } = await extractSegments(
+        timestamp.path,
+        timestampsInSeconds,
+        [],
+        extension,
+        sortableDate,
+        shouldAvoidOptimizations
+      );
 
-    const timestampsInSeconds = {
-      start: getSeconds(timestamp.start),
-      end: getSeconds(timestamp.end),
-    };
+      return { file, commands };
+    } else {
+      const command = `${ffprobe_exe_path} -loglevel error -select_streams v:0 -show_entries packet=pts_time,flags -of csv=print_section=0 "${timestamp.path}"`;
+      const result = await execP(command, { maxBuffer: 1048576000 });
 
-    const { file, commands } = await extractSegments(
-      timestamp.path,
-      timestampsInSeconds,
-      keyframes,
-      extension,
-      sortableDate
-    );
+      const keyframes = [];
+      result.stdout.split(/\r?\n/).forEach((keyframe) => {
+        if (keyframe.includes("K_")) {
+          keyframes.push(parseFloat(keyframe.replace(",K__", "")));
+        }
+      });
 
-    return { file, commands };
+      const timestampsInSeconds = {
+        start: getSeconds(timestamp.start),
+        end: getSeconds(timestamp.end),
+      };
+
+      const { file, commands } = await extractSegments(
+        timestamp.path,
+        timestampsInSeconds,
+        keyframes,
+        extension,
+        sortableDate,
+        shouldAvoidOptimizations
+      );
+
+      return { file, commands };
+    }
+
   } catch (error) {
     console.error(
       `Error processing timestamp ${JSON.stringify(timestamp)}:`,

--- a/cutAndConcatenateVideo/youtubeShort.js
+++ b/cutAndConcatenateVideo/youtubeShort.js
@@ -9,7 +9,7 @@ const youtubeShort = async (fileNameOutput) => {
   const blurredShortFullPathname = `${workingFolderPath}${blurredShortName}`;
 
   const command =
-    `${ffmpeg_exe_path} -i "${workingFolderPath}${fileNameOutput}${getTargetExtension()}" ` +
+    `${ffmpeg_exe_path} -y -i "${workingFolderPath}${fileNameOutput}${getTargetExtension()}" ` +
     `-vf "split[original][copy];[copy]scale=-1:(ih*0.80)*(16/9)*(16/9),crop=w=ih*9/16,gblur=sigma=25[blurred];[blurred][original]overlay=(main_w-overlay_w)/2:(main_h-overlay_h)/2" ` +
     `"${blurredShortFullPathname}"`;
   await execP(command);
@@ -17,7 +17,7 @@ const youtubeShort = async (fileNameOutput) => {
   const compatibleShortName = `${fileNameOutput}_COMPATIBLE_to_youtube_format.mp4`;
   const compatibleShortFullPathName = `${workingFolderPath}${compatibleShortName}`;
   const convertCommand =
-    `${ffmpeg_exe_path} -i "${blurredShortFullPathname}" ` +
+    `${ffmpeg_exe_path} -y -i "${blurredShortFullPathname}" ` +
     `-c:v libx264 -crf 17 -preset fast ` +
     `${compatibleShortFullPathName}`;
   await execP(convertCommand);
@@ -36,7 +36,7 @@ const youtubeShort = async (fileNameOutput) => {
     const imageVideoShortFullPathname = `${workingFolderPath}${imageVideoShortName}`;
 
     const imageCommand =
-      `${ffmpeg_exe_path} -loop 1 -framerate 60 -t 5 -i "${shortsConfig.shortThumbnailPath}" ` +
+      `${ffmpeg_exe_path} -y -loop 1 -framerate 60 -t 5 -i "${shortsConfig.shortThumbnailPath}" ` +
       `-f lavfi -i anullsrc=channel_layout=stereo:sample_rate=48000 -filter_complex "[0]scale=2560:4550:force_original_aspect_ratio=increase,crop=2560:4550,setsar=1,format=yuv420p[v]" ` +
       `-map "[v]" -map 1 -c:v libx264 -c:a aac -shortest "${imageVideoShortFullPathname}"`;
     await execP(imageCommand);

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ import {
 } from "./utils/functions.js";
 import { getTargetExtension } from "./extension.js";
 import { config } from "./config.js";
+import './utils/calculate-duration.js'
 
 const {
   workingFolderPath,

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ const ytConcatenateSlices = async () => {
     const downloadedVideoPaths = downloadResults.filter(
       (path) => path !== null
     );
-
+    console.log('Videos downloaded');
     await cutAndConcatenateVideo();
 
     // Delete temporary video

--- a/utils/functions.js
+++ b/utils/functions.js
@@ -290,7 +290,7 @@ export const getResolutions = async (timestampsWithPaths, ffprobe_exe_path) => {
 
   for (const { path } of timestampsWithPaths) {
     try {
-      const command = `${ffprobe_exe_path} -v error -select_streams v:0 -show_entries stream=width,height -of csv=s=x:p=0 ${path}`;
+      const command = `${ffprobe_exe_path} -v error -select_streams v:0 -show_entries stream=width,height -of csv=s=x:p=0 "${path}"`;
 
       const { stdout, stderr } = await execP(command);
 
@@ -315,7 +315,7 @@ export const getResolutions = async (timestampsWithPaths, ffprobe_exe_path) => {
 // Get the duration in seconds of a video file from the computer
 export const getVideoDurationFile = async (ffprobe_exe_path, path) => {
   try {
-    const command = `${ffprobe_exe_path} -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 ${path}`;
+    const command = `${ffprobe_exe_path} -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "${path}"`;
 
     const { stdout, stderr } = await execP(command);
 


### PR DESCRIPTION
- The script now calculates the duration of the resulting video based on the provided timestamps

It supports:
- Processing files that have multiple audio streams and said streams are then copied and included in the resulting video.
- Video paths with spaces
- Supports multiple source videos with different video formats and extensions. For example, it now can process one `.mp4` file in combination with one `.webm` file. The resulting video will have an `.mp4` format, although this approach needs to re-encode the whole resulting video (it does not applies keyframe optimizations because different formats do not allow that)
